### PR TITLE
Loot Tables Foundation and Block of Ruby Drop

### DIFF
--- a/src/main/resources/data/apollomod/loot_tables/blocks/ruby_block.json
+++ b/src/main/resources/data/apollomod/loot_tables/blocks/ruby_block.json
@@ -1,0 +1,14 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "apollomod:ruby_block"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Get the new `ruby_block.json` file containing the code for the block to drop when mined with the correct tool (iron pickaxe and above), in addition with the new directories `loot_tables` for all the loot tables, and `loot_tables/blocks`, the directory for the loot table of blocks. See goal #6 on the ruby block drop and goal #7 for the loot tables.